### PR TITLE
aarch64: support PAC and BTI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -473,6 +473,11 @@ cc_64_cflags="-O"
 SPEED_CYCLECOUNTER_OBJ=
 cyclecounter_size=2
 
+# architectures can set this to add defines dynamically to m4 generation.
+# For example, in arm64 it is used to determine if PAC and BTI are enabled
+# and enable generation of those instructions in m4 asm.
+gen_path_m4=
+
 AC_SUBST(HAVE_HOST_CPU_FAMILY_power,  0)
 AC_SUBST(HAVE_HOST_CPU_FAMILY_powerpc,0)
 
@@ -781,6 +786,7 @@ case $host in
 	gcc_cflags_arch="-march=armv8-a"
 	gcc_cflags_neon="-mfpu=neon"
 	gcc_cflags_tune=""
+	gen_path_m4="arm64/gen-extra-m4.sh"
 	;;
       [applem[1-9]*])
 	abilist="64"
@@ -4050,6 +4056,12 @@ else
 fi
 AC_PROG_YACC
 AM_PROG_LEX
+
+# This may appear odd, however prefixing with m4 is
+# reserved in m4/autoconf but not in automake and
+# beyond. The prefixed version matches things like
+# gcc_c_flags.
+AC_SUBST([M4_GEN_PATH], [$gen_path_m4])
 
 # Create config.m4.
 GMP_FINISH

--- a/mpn/Makeasm.am
+++ b/mpn/Makeasm.am
@@ -115,4 +115,5 @@ RM_TMP = rm -f
 	$(CCAS) $(COMPILE_FLAGS) tmp-$*.s -o $@
 	$(RM_TMP) tmp-$*.s
 .asm.lo:
-	$(LIBTOOL) --mode=compile --tag=CC $(top_srcdir)/mpn/m4-ccas --m4="$(M4)" $(CCAS) $(COMPILE_FLAGS) `test -f '$<' || echo '$(srcdir)/'`$<
+	$(LIBTOOL) --mode=compile --tag=CC $(top_srcdir)/mpn/m4-ccas --m4-gen-path=$(top_srcdir)/mpn/$(M4_GEN_PATH) --m4="$(M4)" \
+		$(CCAS) $(COMPILE_FLAGS) `test -f '$<' || echo '$(srcdir)/'`$<

--- a/mpn/arm64/aors_n.asm
+++ b/mpn/arm64/aors_n.asm
@@ -60,56 +60,68 @@ ifdef(`OPERATION_sub_n', `
   define(`func_nc',	mpn_sub_nc)')
 
 MULFUNC_PROLOGUE(mpn_add_n mpn_add_nc mpn_sub_n mpn_sub_nc)
+	BTI_C
 
 ASM_START()
 PROLOGUE(func_nc)
+	BTI_C
 	SETCY(	x4)
 	b	L(ent)
 EPILOGUE()
 PROLOGUE(func_n)
+	BTI_C
 	CLRCY
-L(ent):	lsr	x17, n, #2
+L(ent):
+	lsr	x17, n, #2
 	tbz	n, #0, L(bx0)
 
-L(bx1):	ldr	x7, [up]
+L(bx1):
+	ldr	x7, [up]
 	ldr	x11, [vp]
 	ADDSUBC	x13, x7, x11
 	str	x13, [rp],#8
 	tbnz	n, #1, L(b11)
 
-L(b01):	cbz	x17, L(ret)
+L(b01):
+	cbz	x17, L(ret)
 	ldp	x4, x5, [up,#8]
 	ldp	x8, x9, [vp,#8]
 	sub	up, up, #8
 	sub	vp, vp, #8
 	b	L(mid)
 
-L(b11):	ldp	x6, x7, [up,#8]
+L(b11):
+	ldp	x6, x7, [up,#8]
 	ldp	x10, x11, [vp,#8]
 	add	up, up, #8
 	add	vp, vp, #8
 	cbz	x17, L(end)
 	b	L(top)
 
-L(bx0):	tbnz	n, #1, L(b10)
+L(bx0):
+	tbnz	n, #1, L(b10)
 
-L(b00):	ldp	x4, x5, [up]
+L(b00):
+	ldp	x4, x5, [up]
 	ldp	x8, x9, [vp]
 	sub	up, up, #16
 	sub	vp, vp, #16
 	b	L(mid)
 
-L(b10):	ldp	x6, x7, [up]
+L(b10):
+	ldp	x6, x7, [up]
 	ldp	x10, x11, [vp]
 	cbz	x17, L(end)
 
 	ALIGN(16)
-L(top):	ldp	x4, x5, [up,#16]
+L(top):
+	ldp	x4, x5, [up,#16]
 	ldp	x8, x9, [vp,#16]
 	ADDSUBC	x12, x6, x10
 	ADDSUBC	x13, x7, x11
 	stp	x12, x13, [rp],#16
-L(mid):	ldp	x6, x7, [up,#32]!
+L(mid):
+	ldp	x6, x7, [up,#32]!
 	ldp	x10, x11, [vp,#32]!
 	ADDSUBC	x12, x4, x8
 	ADDSUBC	x13, x5, x9
@@ -117,9 +129,12 @@ L(mid):	ldp	x6, x7, [up,#32]!
 	sub	x17, x17, #1
 	cbnz	x17, L(top)
 
-L(end):	ADDSUBC	x12, x6, x10
+L(end):
+	ADDSUBC	x12, x6, x10
 	ADDSUBC	x13, x7, x11
 	stp	x12, x13, [rp]
-L(ret):	RETVAL
+L(ret):
+	RETVAL
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/aorsmul_1.asm
+++ b/mpn/arm64/aorsmul_1.asm
@@ -68,8 +68,10 @@ ifdef(`OPERATION_submul_1', `
   define(`func',	mpn_submul_1)')
 
 MULFUNC_PROLOGUE(mpn_addmul_1 mpn_submul_1)
+	BTI_C
 
 PROLOGUE(func)
+	BTI_C
 	adds	x15, xzr, xzr
 
 	tbz	n, #0, L(1)
@@ -82,7 +84,8 @@ PROLOGUE(func)
 	csinc	x15, x12, x12, COND
 	str	x8, [rp],#8
 
-L(1):	tbz	n, #1, L(2)
+L(1):
+	tbz	n, #1, L(2)
 
 	ldp	x4, x5, [up],#16
 	mul	x8, x4, v0
@@ -98,16 +101,19 @@ L(1):	tbz	n, #1, L(2)
 	csinc	x15, x15, x15, COND
 	stp	x8, x9, [rp],#16
 
-L(2):	lsr	n, n, #2
+L(2):
+	lsr	n, n, #2
 	cbz	n, L(le3)
 	ldp	x4, x5, [up],#32
 	ldp	x6, x7, [up,#-16]
 	b	L(mid)
-L(le3):	mov	x0, x15
+L(le3):
+	mov	x0, x15
 	ret
 
 	ALIGN(16)
-L(top):	ldp	x4, x5, [up],#32
+L(top):
+	ldp	x4, x5, [up],#32
 	ldp	x6, x7, [up,#-16]
 	ADDSUB	x8, x16, x8
 	ADDSUBC	x9, x17, x9
@@ -116,7 +122,8 @@ L(top):	ldp	x4, x5, [up],#32
 	ADDSUBC	x11, x13, x11
 	stp	x10, x11, [rp,#-16]
 	csinc	x15, x15, x15, COND
-L(mid):	sub	n, n, #1
+L(mid):
+	sub	n, n, #1
 	mul	x8, x4, v0
 	umulh	x12, x4, v0
 	mul	x9, x5, v0
@@ -143,3 +150,4 @@ L(mid):	sub	n, n, #1
 	csinc	x0, x15, x15, COND
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/aorsorrlsh1_n.asm
+++ b/mpn/arm64/aorsorrlsh1_n.asm
@@ -39,5 +39,7 @@ ifdef(`OPERATION_sublsh1_n',`define(`DO_sub')')
 ifdef(`OPERATION_rsblsh1_n',`define(`DO_rsb')')
 
 MULFUNC_PROLOGUE(mpn_addlsh1_n mpn_sublsh1_n mpn_rsblsh1_n)
+	BTI_C
 
 include_mpn(`arm64/aorsorrlshC_n.asm')
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/aorsorrlsh2_n.asm
+++ b/mpn/arm64/aorsorrlsh2_n.asm
@@ -39,5 +39,7 @@ ifdef(`OPERATION_sublsh2_n',`define(`DO_sub')')
 ifdef(`OPERATION_rsblsh2_n',`define(`DO_rsb')')
 
 MULFUNC_PROLOGUE(mpn_addlsh2_n mpn_sublsh2_n mpn_rsblsh2_n)
+	BTI_C
 
 include_mpn(`arm64/aorsorrlshC_n.asm')
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/aorsorrlshC_n.asm
+++ b/mpn/arm64/aorsorrlshC_n.asm
@@ -65,13 +65,16 @@ ifdef(`DO_rsb', `
 
 ASM_START()
 PROLOGUE(func_n)
+	BTI_C
 	lsr	x6, n, #2
 	tbz	n, #0, L(bx0)
 
-L(bx1):	ldr	x5, [up]
+L(bx1):
+	ldr	x5, [up]
 	tbnz	n, #1, L(b11)
 
-L(b01):	ldr	x11, [vp]
+L(b01):
+	ldr	x11, [vp]
 	cbz	x6, L(1)
 	ldp	x8, x9, [vp,#8]
 	lsl	x13, x11, #LSH
@@ -81,14 +84,16 @@ L(b01):	ldr	x11, [vp]
 	sub	vp, vp, #8
 	b	L(mid)
 
-L(1):	lsl	x13, x11, #LSH
+L(1):
+	lsl	x13, x11, #LSH
 	ADDSUB(	x15, x13, x5)
 	str	x15, [rp]
 	lsr	x0, x11, RSH
 	RETVAL(	 x0, x1)
 	ret
 
-L(b11):	ldr	x9, [vp]
+L(b11):
+	ldr	x9, [vp]
 	ldp	x10, x11, [vp,#8]!
 	lsl	x13, x9, #LSH
 	ADDSUB(	x17, x13, x5)
@@ -97,27 +102,32 @@ L(b11):	ldr	x9, [vp]
 	cbz	x6, L(end)
 	b	L(top)
 
-L(bx0):	tbnz	n, #1, L(b10)
+L(bx0):
+	tbnz	n, #1, L(b10)
 
-L(b00):	CLRRCY(	x11)
+L(b00):
+	CLRRCY(	x11)
 	ldp	x8, x9, [vp],#-16
 	sub	up, up, #32
 	b	L(mid)
 
-L(b10):	CLRRCY(	x9)
+L(b10):
+	CLRRCY(	x9)
 	ldp	x10, x11, [vp]
 	sub	up, up, #16
 	cbz	x6, L(end)
 
 	ALIGN(16)
-L(top):	ldp	x4, x5, [up,#16]
+L(top):
+	ldp	x4, x5, [up,#16]
 	extr	x12, x10, x9, #RSH
 	ldp	x8, x9, [vp,#16]
 	extr	x13, x11, x10, #RSH
 	ADDSUBC(x14, x12, x4)
 	ADDSUBC(x15, x13, x5)
 	stp	x14, x15, [rp],#16
-L(mid):	ldp	x4, x5, [up,#32]!
+L(mid):
+	ldp	x4, x5, [up,#32]!
 	extr	x12, x8, x11, #RSH
 	ldp	x10, x11, [vp,#32]!
 	extr	x13, x9, x8, #RSH
@@ -127,7 +137,8 @@ L(mid):	ldp	x4, x5, [up,#32]!
 	sub	x6, x6, #1
 	cbnz	x6, L(top)
 
-L(end):	ldp	x4, x5, [up,#16]
+L(end):
+	ldp	x4, x5, [up,#16]
 	extr	x12, x10, x9, #RSH
 	extr	x13, x11, x10, #RSH
 	ADDSUBC(x14, x12, x4)

--- a/mpn/arm64/arm64-defs.m4
+++ b/mpn/arm64/arm64-defs.m4
@@ -36,6 +36,73 @@ dnl  don't want to disable macro expansions in or after them.
 
 changecom
 
+dnl use the hint instructions so they NOP on older machines.
+dnl Add comments so the assembly is notated with the instruction
+
+
+define(`BTI_C', `hint #34    /* bti c */')
+define(`PACIASP', `hint #25  /* paciasp */')
+define(`AUTIASP', `hint #29  /* autiasp */')
+define(`PACIBSP', `hint #27  /* pacibsp */')
+define(`AUTIBSP', `hint #31  /* autibsp */')
+
+dnl if BTI is enabled we want the SIGN_LR to be a valid
+dnl landing pad, we don't need VERIFY_LR and we need to
+dnl indicate the valid BTI support for gnu notes.
+
+
+ifelse(ARM64_FEATURE_BTI_DEFAULT, `1',
+  `define(`SIGN_LR', `BTI_C')
+   define(`GNU_PROPERTY_AARCH64_BTI', `1')
+   define(`PAC_OR_BTI')',
+   define(`GNU_PROPERTY_AARCH64_BTI', `0')'
+')
+
+dnl define instructions for PAC, which can use the A
+dnl or the B key. PAC instructions are also valid BTI
+dnl landing pads, so we re-define SIGN_LR if BTI is
+dnl enabled.
+
+
+ifelse(ARM64_FEATURE_PAC_DEFAULT, `1',
+    `define(`SIGN_LR', `PACIASP')
+     define(`VERIFY_LR', `AUTIASP')
+     define(`GNU_PROPERTY_AARCH64_POINTER_AUTH', `2')
+     define(`PAC_OR_BTI')',
+   ARM64_FEATURE_PAC_DEFAULT, `2',
+    `define(`SIGN_LR', `PACIBSP')
+     define(`VERIFY_LR', `AUTIBSP')
+     define(`GNU_PROPERTY_AARCH64_POINTER_AUTH', `2')
+     define(`PAC_OR_BTI')',
+    `ifdef(`SIGN_LR', , `define(`SIGN_LR', `')')
+     define(`VERIFY_LR', `')
+     define(`GNU_PROPERTY_AARCH64_POINTER_AUTH', `0')'
+')
+
+dnl ADD_GNU_NOTES_IF_NEEDED
+dnl
+dnl Conditionally add into ELF assembly files the GNU notes indicating if
+dnl BTI or PAC is support. BTI is required by the linkers and loaders, however
+dnl PAC is a nice to have for auditing. Use readelf -n to display.
+
+
+define(`ADD_GNU_NOTES_IF_NEEDED', `
+  ifdef(`ARM64_ELF', `
+    ifdef(`PAC_OR_BTI', `
+      .pushsection .note.gnu.property, "a";
+      .balign 8;
+      .long 4;
+      .long 0x10;
+      .long 0x5;
+      .asciz "GNU";
+      .long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+      .long 4;
+      .long eval(indir(`GNU_PROPERTY_AARCH64_POINTER_AUTH') + indir(`GNU_PROPERTY_AARCH64_BTI'));
+      .long 0;
+      .popsection;
+    ')
+  ')
+')
 
 dnl  LEA_HI(reg,gmp_symbol), LEA_LO(reg,gmp_symbol)
 dnl

--- a/mpn/arm64/bdiv_dbm1c.asm
+++ b/mpn/arm64/bdiv_dbm1c.asm
@@ -45,6 +45,7 @@ ASM_START()
 	TEXT
 	ALIGN(16)
 PROLOGUE(mpn_bdiv_dbm1c)
+	BTI_C
 	ldr	x5, [up], #8
 	ands	x6, n, #3
 	b.eq	L(fi0)
@@ -52,60 +53,72 @@ PROLOGUE(mpn_bdiv_dbm1c)
 	b.cc	L(fi1)
 	b.eq	L(fi2)
 
-L(fi3):	mul	x12, x5, bd
+L(fi3):
+	mul	x12, x5, bd
 	umulh	x13, x5, bd
 	ldr	x5, [up], #8
 	b	L(lo3)
 
-L(fi0):	mul	x10, x5, bd
+L(fi0):
+	mul	x10, x5, bd
 	umulh	x11, x5, bd
 	ldr	x5, [up], #8
 	b	L(lo0)
 
-L(fi1):	subs	n, n, #1
+L(fi1):
+	subs	n, n, #1
 	mul	x12, x5, bd
 	umulh	x13, x5, bd
 	b.ls	L(wd1)
 	ldr	x5, [up], #8
 	b	L(lo1)
 
-L(fi2):	mul	x10, x5, bd
+L(fi2):
+	mul	x10, x5, bd
 	umulh	x11, x5, bd
 	ldr	x5, [up], #8
 	b	L(lo2)
 
-L(top):	ldr	x5, [up], #8
+L(top):
+	ldr	x5, [up], #8
 	subs	x4, x4, x10
 	str	x4, [qp], #8
 	sbc	x4, x4, x11
-L(lo1):	mul	x10, x5, bd
+L(lo1):
+	mul	x10, x5, bd
 	umulh	x11, x5, bd
 	ldr	x5, [up], #8
 	subs	x4, x4, x12
 	str	x4, [qp], #8
 	sbc	x4, x4, x13
-L(lo0):	mul	x12, x5, bd
+L(lo0):
+	mul	x12, x5, bd
 	umulh	x13, x5, bd
 	ldr	x5, [up], #8
 	subs	x4, x4, x10
 	str	x4, [qp], #8
 	sbc	x4, x4, x11
-L(lo3):	mul	x10, x5, bd
+L(lo3):
+	mul	x10, x5, bd
 	umulh	x11, x5, bd
 	ldr	x5, [up], #8
 	subs	x4, x4, x12
 	str	x4, [qp], #8
 	sbc	x4, x4, x13
-L(lo2):	subs	n, n, #4
+L(lo2):
+	subs	n, n, #4
 	mul	x12, x5, bd
 	umulh	x13, x5, bd
 	b.hi	L(top)
 
-L(wd2):	subs	x4, x4, x10
+L(wd2):
+	subs	x4, x4, x10
 	str	x4, [qp], #8
 	sbc	x4, x4, x11
-L(wd1):	subs	x4, x4, x12
+L(wd1):
+	subs	x4, x4, x12
 	str	x4, [qp]
 	sbc	x0, x4, x13
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/bdiv_q_1.asm
+++ b/mpn/arm64/bdiv_q_1.asm
@@ -56,6 +56,7 @@ define(`tnc', `x8')
 
 ASM_START()
 PROLOGUE(mpn_bdiv_q_1)
+	BTI_C
 
 	rbit	x6, d
 	clz	cnt, x6
@@ -79,17 +80,20 @@ PROLOGUE(mpn_bdiv_q_1)
 EPILOGUE()
 
 PROLOGUE(mpn_pi1_bdiv_q_1)
+	BTI_C
 	sub	n, n, #1
 	subs	x6, x6, x6		C clear r6 and C flag
 	ldr	x9, [up],#8
 	cbz	cnt, L(norm)
 
 L(unorm):
+
 	lsr	x12, x9, cnt
 	cbz	n, L(eu1)
 	sub	tnc, xzr, cnt
 
-L(tpu):	ldr	x9, [up],#8
+L(tpu):
+	ldr	x9, [up],#8
 	lsl	x7, x9, tnc
 	orr	x7, x7, x12
 	sbcs	x6, x7, x6
@@ -100,17 +104,20 @@ L(tpu):	ldr	x9, [up],#8
 	sub	n, n, #1
 	cbnz	n, L(tpu)
 
-L(eu1):	sbcs	x6, x12, x6
+L(eu1):
+	sbcs	x6, x12, x6
 	mul	x6, x6, di
 	str	x6, [rp]
 	ret
 
 L(norm):
+
 	mul	x5, x9, di
 	str	x5, [rp],#8
 	cbz	n, L(en1)
 
-L(tpn):	ldr	x9, [up],#8
+L(tpn):
+	ldr	x9, [up],#8
 	umulh	x5, x5, d
 	sbcs	x5, x9, x5
 	mul	x5, x5, di
@@ -118,5 +125,7 @@ L(tpn):	ldr	x9, [up],#8
 	sub	n, n, #1
 	cbnz	n, L(tpn)
 
-L(en1):	ret
+L(en1):
+	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/cnd_aors_n.asm
+++ b/mpn/arm64/cnd_aors_n.asm
@@ -57,9 +57,11 @@ ifdef(`OPERATION_cnd_sub_n', `
   define(`func',	mpn_cnd_sub_n)')
 
 MULFUNC_PROLOGUE(mpn_cnd_add_n mpn_cnd_sub_n)
+	BTI_C
 
 ASM_START()
 PROLOGUE(func)
+	BTI_C
 	cmp	cnd, #1
 	sbc	cnd, cnd, cnd
 
@@ -68,14 +70,16 @@ PROLOGUE(func)
 	lsr	x17, n, #2
 	tbz	n, #0, L(bx0)
 
-L(bx1):	ldr	x13, [vp]
+L(bx1):
+	ldr	x13, [vp]
 	ldr	x11, [up]
 	bic	x7, x13, cnd
 	ADDSUBC	x9, x11, x7
 	str	x9, [rp]
 	tbnz	n, #1, L(b11)
 
-L(b01):	cbz	x17, L(rt)
+L(b01):
+	cbz	x17, L(rt)
 	ldp	x12, x13, [vp,#8]
 	ldp	x10, x11, [up,#8]
 	sub	up, up, #8
@@ -83,33 +87,39 @@ L(b01):	cbz	x17, L(rt)
 	sub	rp, rp, #24
 	b	L(mid)
 
-L(b11):	ldp	x12, x13, [vp,#8]!
+L(b11):
+	ldp	x12, x13, [vp,#8]!
 	ldp	x10, x11, [up,#8]!
 	sub	rp, rp, #8
 	cbz	x17, L(end)
 	b	L(top)
 
-L(bx0):	ldp	x12, x13, [vp]
+L(bx0):
+	ldp	x12, x13, [vp]
 	ldp	x10, x11, [up]
 	tbnz	n, #1, L(b10)
 
-L(b00):	sub	up, up, #16
+L(b00):
+	sub	up, up, #16
 	sub	vp, vp, #16
 	sub	rp, rp, #32
 	b	L(mid)
 
-L(b10):	sub	rp, rp, #16
+L(b10):
+	sub	rp, rp, #16
 	cbz	x17, L(end)
 
 	ALIGN(16)
-L(top):	bic	x6, x12, cnd
+L(top):
+	bic	x6, x12, cnd
 	bic	x7, x13, cnd
 	ldp	x12, x13, [vp,#16]
 	ADDSUBC	x8, x10, x6
 	ADDSUBC	x9, x11, x7
 	ldp	x10, x11, [up,#16]
 	stp	x8, x9, [rp,#16]
-L(mid):	bic	x6, x12, cnd
+L(mid):
+	bic	x6, x12, cnd
 	bic	x7, x13, cnd
 	ldp	x12, x13, [vp,#32]!
 	ADDSUBC	x8, x10, x6
@@ -119,11 +129,14 @@ L(mid):	bic	x6, x12, cnd
 	sub	x17, x17, #1
 	cbnz	x17, L(top)
 
-L(end):	bic	x6, x12, cnd
+L(end):
+	bic	x6, x12, cnd
 	bic	x7, x13, cnd
 	ADDSUBC	x8, x10, x6
 	ADDSUBC	x9, x11, x7
 	stp	x8, x9, [rp,#16]
-L(rt):	RETVAL
+L(rt):
+	RETVAL
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/com.asm
+++ b/mpn/arm64/com.asm
@@ -47,6 +47,7 @@ define(`n',  `x2')
 
 ASM_START()
 PROLOGUE(mpn_com)
+	BTI_C
 	cmp	n, #3
 	b.le	L(bc)
 
@@ -57,12 +58,14 @@ C Copy until rp is 128-bit aligned
 	mvn	x4, x4
 	str	x4, [rp],#8
 
-L(al2):	ldp	x4,x5, [up],#16
+L(al2):
+	ldp	x4,x5, [up],#16
 	sub	n, n, #6
 	tbnz	n, #63, L(end)
 
 	ALIGN(16)
-L(top):	ldp	x6,x7, [up],#32
+L(top):
+	ldp	x6,x7, [up],#32
 	mvn	x4, x4
 	mvn	x5, x5
 	stp	x4,x5, [rp],#32
@@ -73,20 +76,25 @@ L(top):	ldp	x6,x7, [up],#32
 	sub	n, n, #4
 	tbz	n, #63, L(top)
 
-L(end):	mvn	x4, x4
+L(end):
+	mvn	x4, x4
 	mvn	x5, x5
 	stp	x4,x5, [rp],#16
 
 C Copy last 0-3 limbs.  Note that rp is aligned after loop, but not when we
 C arrive here via L(bc)
-L(bc):	tbz	n, #1, L(tl1)
+L(bc):
+	tbz	n, #1, L(tl1)
 	ldp	x4,x5, [up],#16
 	mvn	x4, x4
 	mvn	x5, x5
 	stp	x4,x5, [rp],#16
-L(tl1):	tbz	n, #0, L(tl2)
+L(tl1):
+	tbz	n, #0, L(tl2)
 	ldr	x4, [up]
 	mvn	x4, x4
 	str	x4, [rp]
-L(tl2):	ret
+L(tl2):
+	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/copyd.asm
+++ b/mpn/arm64/copyd.asm
@@ -47,6 +47,7 @@ define(`n',  `x2')
 
 ASM_START()
 PROLOGUE(mpn_copyd)
+	BTI_C
 	add	rp, rp, n, lsl #3
 	add	up, up, n, lsl #3
 
@@ -59,27 +60,34 @@ C Copy until rp is 128-bit aligned
 	sub	n, n, #1
 	str	x4, [rp,#-8]!
 
-L(al2):	ldp	x4,x5, [up,#-16]!
+L(al2):
+	ldp	x4,x5, [up,#-16]!
 	sub	n, n, #6
 	tbnz	n, #63, L(end)
 
 	ALIGN(16)
-L(top):	ldp	x6,x7, [up,#-16]
+L(top):
+	ldp	x6,x7, [up,#-16]
 	stp	x4,x5, [rp,#-16]
 	ldp	x4,x5, [up,#-32]!
 	stp	x6,x7, [rp,#-32]!
 	sub	n, n, #4
 	tbz	n, #63, L(top)
 
-L(end):	stp	x4,x5, [rp,#-16]!
+L(end):
+	stp	x4,x5, [rp,#-16]!
 
 C Copy last 0-3 limbs.  Note that rp is aligned after loop, but not when we
 C arrive here via L(bc)
-L(bc):	tbz	n, #1, L(tl1)
+L(bc):
+	tbz	n, #1, L(tl1)
 	ldp	x4,x5, [up,#-16]!
 	stp	x4,x5, [rp,#-16]!
-L(tl1):	tbz	n, #0, L(tl2)
+L(tl1):
+	tbz	n, #0, L(tl2)
 	ldr	x4, [up,#-8]
 	str	x4, [rp,#-8]
-L(tl2):	ret
+L(tl2):
+	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/copyi.asm
+++ b/mpn/arm64/copyi.asm
@@ -47,6 +47,7 @@ define(`n',  `x2')
 
 ASM_START()
 PROLOGUE(mpn_copyi)
+	BTI_C
 	cmp	n, #3
 	b.le	L(bc)
 
@@ -56,27 +57,34 @@ C Copy until rp is 128-bit aligned
 	sub	n, n, #1
 	str	x4, [rp],#8
 
-L(al2):	ldp	x4,x5, [up],#16
+L(al2):
+	ldp	x4,x5, [up],#16
 	sub	n, n, #6
 	tbnz	n, #63, L(end)
 
 	ALIGN(16)
-L(top):	ldp	x6,x7, [up],#32
+L(top):
+	ldp	x6,x7, [up],#32
 	stp	x4,x5, [rp],#32
 	ldp	x4,x5, [up,#-16]
 	stp	x6,x7, [rp,#-16]
 	sub	n, n, #4
 	tbz	n, #63, L(top)
 
-L(end):	stp	x4,x5, [rp],#16
+L(end):
+	stp	x4,x5, [rp],#16
 
 C Copy last 0-3 limbs.  Note that rp is aligned after loop, but not when we
 C arrive here via L(bc)
-L(bc):	tbz	n, #1, L(tl1)
+L(bc):
+	tbz	n, #1, L(tl1)
 	ldp	x4,x5, [up],#16
 	stp	x4,x5, [rp],#16
-L(tl1):	tbz	n, #0, L(tl2)
+L(tl1):
+	tbz	n, #0, L(tl2)
 	ldr	x4, [up]
 	str	x4, [rp]
-L(tl2):	ret
+L(tl2):
+	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/divrem_1.asm
+++ b/mpn/arm64/divrem_1.asm
@@ -66,6 +66,8 @@ dnl                      mp_limb_t d_unnorm, mp_limb_t dinv, int cnt)
 ASM_START()
 
 PROLOGUE(mpn_preinv_divrem_1)
+	BTI_C
+	SIGN_LR
 	cbz	n_arg, L(fz)
 	stp	x29, x30, [sp, #-80]!
 	mov	x29, sp
@@ -86,6 +88,8 @@ PROLOGUE(mpn_preinv_divrem_1)
 EPILOGUE()
 
 PROLOGUE(mpn_divrem_1)
+	BTI_C
+	SIGN_LR
 	cbz	n_arg, L(fz)
 	stp	x29, x30, [sp, #-80]!
 	mov	x29, sp
@@ -102,10 +106,12 @@ PROLOGUE(mpn_divrem_1)
 	tbnz	d_arg, #63, L(normalised)
 
 L(unnorm):
+
 	clz	cnt, d
 	lsl	x0, d, cnt
 	bl	GSYM_PREFIX`'MPN(invert_limb)
 L(uentry):
+
 	lsl	d, d, cnt
 	ldr	x7, [np], #-8
 	sub	tnc, xzr, cnt
@@ -113,7 +119,8 @@ L(uentry):
 	lsl	x1, x7, cnt
 	cbz	n, L(uend)
 
-L(utop):ldr	x7, [np], #-8
+L(utop):
+ldr	x7, [np], #-8
 	add	x2, x11, #1
 	mul	x10, x11, dinv
 	umulh	x17, x11, dinv
@@ -129,11 +136,13 @@ L(utop):ldr	x7, [np], #-8
 	sbc	x2, x2, xzr
 	cmp	x11, d
 	bcs	L(ufx)
-L(uok):	str	x2, [qp], #-8
+L(uok):
+	str	x2, [qp], #-8
 	sub	n, n, #1
 	cbnz	n, L(utop)
 
-L(uend):add	x2, x11, #1
+L(uend):
+add	x2, x11, #1
 	mul	x10, x11, dinv
 	umulh	x17, x11, dinv
 	adds	x10, x1, x10
@@ -154,24 +163,29 @@ L(uend):add	x2, x11, #1
 	ldp	x21, x22, [sp, #32]
 	ldp	x23, x24, [sp, #48]
 	ldp	x29, x30, [sp], #80
+	VERIFY_LR
 	ret
 
-L(ufx):	add	x2, x2, #1
+L(ufx):
+	add	x2, x2, #1
 	sub	x11, x11, d
 	b	L(uok)
 
 
 L(normalised):
+
 	mov	x0, d
 	bl	GSYM_PREFIX`'MPN(invert_limb)
 L(nentry):
+
 	ldr	x7, [np], #-8
 	subs	x14, x7, d
 	adc	x2, xzr, xzr		C hi q limb
 	csel	x11, x14, x7, cs
 	b	L(nok)
 
-L(ntop):ldr	x1, [np], #-8
+L(ntop):
+ldr	x1, [np], #-8
 	add	x2, x11, #1
 	mul	x10, x11, dinv
 	umulh	x17, x11, dinv
@@ -184,24 +198,30 @@ L(ntop):ldr	x1, [np], #-8
 	sbc	x2, x2, xzr
 	cmp	x11, d
 	bcs	L(nfx)
-L(nok):	str	x2, [qp], #-8
+L(nok):
+	str	x2, [qp], #-8
 	sub	n, n, #1
 	tbz	n, #63, L(ntop)
 
-L(nend):cbnz	fn, L(frac)
+L(nend):
+cbnz	fn, L(frac)
 	mov	x0, x11
 	ldp	x19, x20, [sp, #16]
 	ldp	x21, x22, [sp, #32]
 	ldp	x23, x24, [sp, #48]
 	ldp	x29, x30, [sp], #80
+	VERIFY_LR
 	ret
 
-L(nfx):	add	x2, x2, #1
+L(nfx):
+	add	x2, x2, #1
 	sub	x11, x11, d
 	b	L(nok)
 
-L(frac):mov	cnt, #0
-L(ftop):add	x2, x11, #1
+L(frac):
+mov	cnt, #0
+L(ftop):
+add	x2, x11, #1
 	mul	x10, x11, dinv
 	umulh	x17, x11, dinv
 	add	x2, x2, x17
@@ -219,13 +239,19 @@ L(ftop):add	x2, x11, #1
 	ldp	x21, x22, [sp, #32]
 	ldp	x23, x24, [sp, #48]
 	ldp	x29, x30, [sp], #80
+	VERIFY_LR
 	ret
 
 C Block zero. We need this for the degenerated case of n = 0, fn != 0.
-L(fz):	cbz	fn_arg, L(zend)
-L(ztop):str	xzr, [qp_arg], #8
+L(fz):
+	cbz	fn_arg, L(zend)
+L(ztop):
+str	xzr, [qp_arg], #8
 	sub	fn_arg, fn_arg, #1
 	cbnz	fn_arg, L(ztop)
-L(zend):mov	x0, #0
+L(zend):
+mov	x0, #0
+	VERIFY_LR
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/gcd_11.asm
+++ b/mpn/arm64/gcd_11.asm
@@ -54,11 +54,13 @@ ASM_START()
 	TEXT
 	ALIGN(16)
 PROLOGUE(mpn_gcd_11)
+	BTI_C
 	subs	x3, u0, v0		C			0
 	b.eq	L(end)			C
 
 	ALIGN(16)
-L(top):	rbit	x12, x3			C			1,5
+L(top):
+	rbit	x12, x3			C			1,5
 	clz	x12, x12		C			2
 	csneg	x3, x3, x3, cs		C v = abs(u-v), even	1
 	csel	u0, v0, u0, cs		C u = min(u,v)		1
@@ -66,5 +68,7 @@ L(top):	rbit	x12, x3			C			1,5
 	subs	x3, u0, v0		C			4
 	b.ne	L(top)			C
 
-L(end):	ret
+L(end):
+	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/gcd_22.asm
+++ b/mpn/arm64/gcd_22.asm
@@ -56,9 +56,11 @@ define(`tnc',   `x8')
 
 ASM_START()
 PROLOGUE(mpn_gcd_22)
+	BTI_C
 
 	ALIGN(16)
-L(top):	subs	t0, u0, v0		C 0 6
+L(top):
+	subs	t0, u0, v0		C 0 6
 	cbz	t0, L(lowz)
 	sbcs	t1, u1, v1		C 1 7
 
@@ -66,7 +68,8 @@ L(top):	subs	t0, u0, v0		C 0 6
 
 	cneg	t0, t0, cc		C 2
 	cinv	t1, t1, cc		C 2 u = |u - v|
-L(bck):	csel	v0, v0, u0, cs		C 2
+L(bck):
+	csel	v0, v0, u0, cs		C 2
 	csel	v1, v1, u1, cs		C 2 v = min(u,v)
 
 	clz	cnt, cnt		C 2
@@ -85,18 +88,21 @@ L(bck):	csel	v0, v0, u0, cs		C 2
 	b.eq	L(end1)			C
 
 	ALIGN(16)
-L(top1):rbit	x12, x4			C			1,5
+L(top1):
+rbit	x12, x4			C			1,5
 	clz	x12, x12		C			2
 	csneg	x4, x4, x4, cs		C v = abs(u-v), even	1
 	csel	u0, v0, u0, cs		C u = min(u,v)		1
 	lsr	v0, x4, x12		C			3
 	subs	x4, u0, v0		C			4
 	b.ne	L(top1)			C
-L(end1):mov	x0, u0
+L(end1):
+mov	x0, u0
 	mov	x1, #0
 	ret
 
-L(lowz):C We come here when v0 - u0 = 0
+L(lowz):
+C We come here when v0 - u0 = 0
 	C 1. If v1 - u1 = 0, then gcd is u = v.
 	C 2. Else compute gcd_21({v1,v0}, |u1-v1|)
 	subs	t0, u1, v1
@@ -106,7 +112,9 @@ L(lowz):C We come here when v0 - u0 = 0
 	cneg	t0, t0, cc		C 2
 	b	L(bck)			C FIXME: make conditional
 
-L(end):	mov	x0, v0
+L(end):
+	mov	x0, v0
 	mov	x1, v1
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/gen-extra-m4.sh
+++ b/mpn/arm64/gen-extra-m4.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+#
+# A script for dynamically generating m4 definitions for aarch64 based on compilation flags.
+#
+# Copyright 2024 ARM Ltd.
+#
+#  This file is part of the GNU MP Library.
+#
+#  The GNU MP Library is free software; you can redistribute it and/or modify
+#  it under the terms of either:
+#
+#    * the GNU Lesser General Public License as published by the Free
+#      Software Foundation; either version 3 of the License, or (at your
+#      option) any later version.
+#
+#  or
+#
+#    * the GNU General Public License as published by the Free Software
+#      Foundation; either version 2 of the License, or (at your option) any
+#      later version.
+#
+#  or both in parallel, as here.
+#
+#  The GNU MP Library is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+#  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#  for more details.
+#
+#  You should have received copies of the GNU General Public License and the
+#  GNU Lesser General Public License along with the GNU MP Library.  If not,
+#  see https://www.gnu.org/licenses/.
+
+# Usage: ./gen-extra-m4.sh "$CC"
+# Returns: valid M4 to stdout.
+
+if test "$#" -ne 1; then
+  echo "Expected 1 argument, the CC. Got: $#"
+  exit 1
+fi
+
+CC=$1
+
+ARM64_FEATURE_BTI_DEFAULT="0"
+ARM64_FEATURE_PAC_DEFAULT="0"
+ARM64_ELF="0"
+
+# strip -o from CC line so -dM works
+_CC=$(echo "$CC" | sed 's/-o [^ ]*//')
+output=$($_CC -dM -E - < /dev/null || exit $?)
+while IFS= read -r line; do
+  # Skip empty lines
+  if test -z "$line"; then
+    continue
+  fi
+  # Match the #define pattern and extract the macro name and value
+  case "$line" in
+    \#define\ *\ *)
+      macro_name=`echo "$line" | awk '{print $2}'`
+      macro_value=`echo "$line" | cut -d ' ' -f 3- | sed 's/^"\(.*\)"$/\1/'`
+      # map's would be nice in POSIX shell, could use eval to simplify, but
+      # I won't do that to others.
+      case "$macro_name" in
+        __ARM_FEATURE_BTI_DEFAULT)
+          ARM64_FEATURE_BTI_DEFAULT="$macro_value"
+        ;;
+        __ARM_FEATURE_PAC_DEFAULT)
+          ARM64_FEATURE_PAC_DEFAULT="$macro_value"
+        ;;
+        __ELF__)
+          ARM64_ELF="$macro_value"
+        ;;
+      esac # end assignments
+      ;;
+  esac # end define
+done <<< "$output"
+
+# Output the M4 define statement. To make m4 simpler always output something so we can
+# use an ifelse without needing to nest it within an ifdef.
+echo "define(\`ARM64_FEATURE_BTI_DEFAULT', \`$ARM64_FEATURE_BTI_DEFAULT')"
+echo "define(\`ARM64_FEATURE_PAC_DEFAULT', \`$ARM64_FEATURE_PAC_DEFAULT')"
+echo "define(\`ARM64_ELF', \`$ARM64_ELF')"

--- a/mpn/arm64/invert_limb.asm
+++ b/mpn/arm64/invert_limb.asm
@@ -40,6 +40,7 @@ C Compiler generated, mildly edited.  Could surely be further optimised.
 
 ASM_START()
 PROLOGUE(mpn_invert_limb)
+	BTI_C
 	lsr	x2, x0, #54
 	LEA_HI(	x1, approx_tab)
 	and	x2, x2, #0x1fe
@@ -81,3 +82,4 @@ approx_tab:
 forloop(i,256,512-1,dnl
 `	.hword	eval(0x7fd00/i)
 ')dnl
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/logops_n.asm
+++ b/mpn/arm64/logops_n.asm
@@ -75,52 +75,62 @@ ifdef(`OPERATION_xnor_n',`
   define(`LOGOP',   `eon	$1, $2, $3')')
 
 MULFUNC_PROLOGUE(mpn_and_n mpn_andn_n mpn_nand_n mpn_ior_n mpn_iorn_n mpn_nior_n mpn_xor_n mpn_xnor_n)
+	BTI_C
 
 ASM_START()
 PROLOGUE(func)
+	BTI_C
 	lsr	x17, n, #2
 	tbz	n, #0, L(bx0)
 
-L(bx1):	ldr	x7, [up]
+L(bx1):
+	ldr	x7, [up]
 	ldr	x11, [vp]
 	LOGOP(	x15, x7, x11)
 	POSTOP(	x15)
 	str	x15, [rp],#8
 	tbnz	n, #1, L(b11)
 
-L(b01):	cbz	x17, L(ret)
+L(b01):
+	cbz	x17, L(ret)
 	ldp	x4, x5, [up,#8]
 	ldp	x8, x9, [vp,#8]
 	sub	up, up, #8
 	sub	vp, vp, #8
 	b	L(mid)
 
-L(b11):	ldp	x6, x7, [up,#8]
+L(b11):
+	ldp	x6, x7, [up,#8]
 	ldp	x10, x11, [vp,#8]
 	add	up, up, #8
 	add	vp, vp, #8
 	cbz	x17, L(end)
 	b	L(top)
 
-L(bx0):	tbnz	n, #1, L(b10)
+L(bx0):
+	tbnz	n, #1, L(b10)
 
-L(b00):	ldp	x4, x5, [up],#-16
+L(b00):
+	ldp	x4, x5, [up],#-16
 	ldp	x8, x9, [vp],#-16
 	b	L(mid)
 
-L(b10):	ldp	x6, x7, [up]
+L(b10):
+	ldp	x6, x7, [up]
 	ldp	x10, x11, [vp]
 	cbz	x17, L(end)
 
 	ALIGN(16)
-L(top):	ldp	x4, x5, [up,#16]
+L(top):
+	ldp	x4, x5, [up,#16]
 	ldp	x8, x9, [vp,#16]
 	LOGOP(	x12, x6, x10)
 	LOGOP(	x13, x7, x11)
 	POSTOP(	x12)
 	POSTOP(	x13)
 	stp	x12, x13, [rp],#16
-L(mid):	ldp	x6, x7, [up,#32]!
+L(mid):
+	ldp	x6, x7, [up,#32]!
 	ldp	x10, x11, [vp,#32]!
 	LOGOP(	x12, x4, x8)
 	LOGOP(	x13, x5, x9)
@@ -130,10 +140,13 @@ L(mid):	ldp	x6, x7, [up,#32]!
 	sub	x17, x17, #1
 	cbnz	x17, L(top)
 
-L(end):	LOGOP(	x12, x6, x10)
+L(end):
+	LOGOP(	x12, x6, x10)
 	LOGOP(	x13, x7, x11)
 	POSTOP(	x12)
 	POSTOP(	x13)
 	stp	x12, x13, [rp]
-L(ret):	ret
+L(ret):
+	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/lshift.asm
+++ b/mpn/arm64/lshift.asm
@@ -58,34 +58,41 @@ define(`NSHIFT', lsr)
 
 ASM_START()
 PROLOGUE(mpn_lshift)
+	BTI_C
 	add	rp, rp_arg, n, lsl #3
 	add	up, up, n, lsl #3
 	sub	tnc, xzr, cnt
 	lsr	x17, n, #2
 	tbz	n, #0, L(bx0)
 
-L(bx1):	ldr	x4, [up,#-8]
+L(bx1):
+	ldr	x4, [up,#-8]
 	tbnz	n, #1, L(b11)
 
-L(b01):	NSHIFT	x0, x4, tnc
+L(b01):
+	NSHIFT	x0, x4, tnc
 	PSHIFT	x2, x4, cnt
 	cbnz	x17, L(gt1)
 	str	x2, [rp,#-8]
 	ret
-L(gt1):	ldp	x4, x5, [up,#-24]
+L(gt1):
+	ldp	x4, x5, [up,#-24]
 	sub	up, up, #8
 	add	rp, rp, #16
 	b	L(lo2)
 
-L(b11):	NSHIFT	x0, x4, tnc
+L(b11):
+	NSHIFT	x0, x4, tnc
 	PSHIFT	x2, x4, cnt
 	ldp	x6, x7, [up,#-24]!
 	b	L(lo3)
 
-L(bx0):	ldp	x4, x5, [up,#-16]
+L(bx0):
+	ldp	x4, x5, [up,#-16]
 	tbz	n, #1, L(b00)
 
-L(b10):	NSHIFT	x0, x5, tnc
+L(b10):
+	NSHIFT	x0, x5, tnc
 	PSHIFT	x13, x5, cnt
 	NSHIFT	x10, x4, tnc
 	PSHIFT	x2, x4, cnt
@@ -93,14 +100,16 @@ L(b10):	NSHIFT	x0, x5, tnc
 	orr	x10, x10, x13
 	stp	x2, x10, [rp,#-16]
 	ret
-L(gt2):	ldp	x4, x5, [up,#-32]
+L(gt2):
+	ldp	x4, x5, [up,#-32]
 	orr	x10, x10, x13
 	str	x10, [rp,#-8]
 	sub	up, up, #16
 	add	rp, rp, #8
 	b	L(lo2)
 
-L(b00):	NSHIFT	x0, x5, tnc
+L(b00):
+	NSHIFT	x0, x5, tnc
 	PSHIFT	x13, x5, cnt
 	NSHIFT	x10, x4, tnc
 	PSHIFT	x2, x4, cnt
@@ -110,12 +119,14 @@ L(b00):	NSHIFT	x0, x5, tnc
 	b	L(lo0)
 
 	ALIGN(16)
-L(top):	ldp	x4, x5, [up,#-16]
+L(top):
+	ldp	x4, x5, [up,#-16]
 	orr	x10, x10, x13
 	orr	x11, x12, x2
 	stp	x10, x11, [rp,#-16]
 	PSHIFT	x2, x6, cnt
-L(lo2):	NSHIFT	x10, x4, tnc
+L(lo2):
+	NSHIFT	x10, x4, tnc
 	PSHIFT	x13, x5, cnt
 	NSHIFT	x12, x5, tnc
 	ldp	x6, x7, [up,#-32]!
@@ -123,16 +134,20 @@ L(lo2):	NSHIFT	x10, x4, tnc
 	orr	x11, x12, x2
 	stp	x10, x11, [rp,#-32]!
 	PSHIFT	x2, x4, cnt
-L(lo0):	sub	x17, x17, #1
-L(lo3):	NSHIFT	x10, x6, tnc
+L(lo0):
+	sub	x17, x17, #1
+L(lo3):
+	NSHIFT	x10, x6, tnc
 	PSHIFT	x13, x7, cnt
 	NSHIFT	x12, x7, tnc
 	cbnz	x17, L(top)
 
-L(end):	orr	x10, x10, x13
+L(end):
+	orr	x10, x10, x13
 	orr	x11, x12, x2
 	PSHIFT	x2, x6, cnt
 	stp	x10, x11, [rp,#-16]
 	str	x2, [rp,#-24]
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/lshiftc.asm
+++ b/mpn/arm64/lshiftc.asm
@@ -58,35 +58,42 @@ define(`NSHIFT', lsr)
 
 ASM_START()
 PROLOGUE(mpn_lshiftc)
+	BTI_C
 	add	rp, rp_arg, n, lsl #3
 	add	up, up, n, lsl #3
 	sub	tnc, xzr, cnt
 	lsr	x17, n, #2
 	tbz	n, #0, L(bx0)
 
-L(bx1):	ldr	x4, [up,#-8]
+L(bx1):
+	ldr	x4, [up,#-8]
 	tbnz	n, #1, L(b11)
 
-L(b01):	NSHIFT	x0, x4, tnc
+L(b01):
+	NSHIFT	x0, x4, tnc
 	PSHIFT	x2, x4, cnt
 	cbnz	x17, L(gt1)
 	mvn	x2, x2
 	str	x2, [rp,#-8]
 	ret
-L(gt1):	ldp	x4, x5, [up,#-24]
+L(gt1):
+	ldp	x4, x5, [up,#-24]
 	sub	up, up, #8
 	add	rp, rp, #16
 	b	L(lo2)
 
-L(b11):	NSHIFT	x0, x4, tnc
+L(b11):
+	NSHIFT	x0, x4, tnc
 	PSHIFT	x2, x4, cnt
 	ldp	x6, x7, [up,#-24]!
 	b	L(lo3)
 
-L(bx0):	ldp	x4, x5, [up,#-16]
+L(bx0):
+	ldp	x4, x5, [up,#-16]
 	tbz	n, #1, L(b00)
 
-L(b10):	NSHIFT	x0, x5, tnc
+L(b10):
+	NSHIFT	x0, x5, tnc
 	PSHIFT	x13, x5, cnt
 	NSHIFT	x10, x4, tnc
 	PSHIFT	x2, x4, cnt
@@ -95,14 +102,16 @@ L(b10):	NSHIFT	x0, x5, tnc
 	mvn	x2, x2
 	stp	x2, x10, [rp,#-16]
 	ret
-L(gt2):	ldp	x4, x5, [up,#-32]
+L(gt2):
+	ldp	x4, x5, [up,#-32]
 	eon	x10, x10, x13
 	str	x10, [rp,#-8]
 	sub	up, up, #16
 	add	rp, rp, #8
 	b	L(lo2)
 
-L(b00):	NSHIFT	x0, x5, tnc
+L(b00):
+	NSHIFT	x0, x5, tnc
 	PSHIFT	x13, x5, cnt
 	NSHIFT	x10, x4, tnc
 	PSHIFT	x2, x4, cnt
@@ -112,12 +121,14 @@ L(b00):	NSHIFT	x0, x5, tnc
 	b	L(lo0)
 
 	ALIGN(16)
-L(top):	ldp	x4, x5, [up,#-16]
+L(top):
+	ldp	x4, x5, [up,#-16]
 	eon	x10, x10, x13
 	eon	x11, x12, x2
 	stp	x10, x11, [rp,#-16]
 	PSHIFT	x2, x6, cnt
-L(lo2):	NSHIFT	x10, x4, tnc
+L(lo2):
+	NSHIFT	x10, x4, tnc
 	PSHIFT	x13, x5, cnt
 	NSHIFT	x12, x5, tnc
 	ldp	x6, x7, [up,#-32]!
@@ -125,13 +136,16 @@ L(lo2):	NSHIFT	x10, x4, tnc
 	eon	x11, x12, x2
 	stp	x10, x11, [rp,#-32]!
 	PSHIFT	x2, x4, cnt
-L(lo0):	sub	x17, x17, #1
-L(lo3):	NSHIFT	x10, x6, tnc
+L(lo0):
+	sub	x17, x17, #1
+L(lo3):
+	NSHIFT	x10, x6, tnc
 	PSHIFT	x13, x7, cnt
 	NSHIFT	x12, x7, tnc
 	cbnz	x17, L(top)
 
-L(end):	eon	x10, x10, x13
+L(end):
+	eon	x10, x10, x13
 	eon	x11, x12, x2
 	PSHIFT	x2, x6, cnt
 	stp	x10, x11, [rp,#-16]
@@ -139,3 +153,4 @@ L(end):	eon	x10, x10, x13
 	str	x2, [rp,#-24]
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/mod_34lsub1.asm
+++ b/mpn/arm64/mod_34lsub1.asm
@@ -62,6 +62,7 @@ ASM_START()
 	TEXT
 	ALIGN(32)
 PROLOGUE(mpn_mod_34lsub1)
+	BTI_C
 	subs	n, n, #3
 	mov	x8, #0
 	b.lt	L(le2)			C n <= 2
@@ -73,7 +74,8 @@ PROLOGUE(mpn_mod_34lsub1)
 	b.lt	L(sum)			C n <= 5
 	cmn	x0, #0			C clear carry
 
-L(top):	ldp	x5, x6, [ap, #0]
+L(top):
+	ldp	x5, x6, [ap, #0]
 	ldr	x7, [ap, #16]
 	add	ap, ap, #24
 	sub	n, n, #3
@@ -84,19 +86,23 @@ L(top):	ldp	x5, x6, [ap, #0]
 
 	adc	x8, xzr, xzr		C x8 <= 1
 
-L(sum):	cmn	n, #2
+L(sum):
+	cmn	n, #2
 	mov	x5, #0
 	b.lo	1f
 	ldr	x5, [ap], #8
-1:	mov	x6, #0
+1:
+	mov	x6, #0
 	b.ls	1f
 	ldr	x6, [ap], #8
-1:	adds	x2, x2, x5
+1:
+	adds	x2, x2, x5
 	adcs	x3, x3, x6
 	adcs	x4, x4, xzr
 	adc	x8, x8, xzr		C x8 <= 2
 
 L(sum2):
+
 	and	x0, x2, #0xffffffffffff
 	add	x0, x0, x2, lsr #48
 	add	x0, x0, x8
@@ -112,13 +118,16 @@ L(sum2):
 	add	x0, x0, x4, lsr #16
 	ret
 
-L(le2):	cmn	n, #1
+L(le2):
+	cmn	n, #1
 	b.ne	L(1)
 	ldp	x2, x3, [ap]
 	mov	x4, #0
 	b	L(sum2)
-L(1):	ldr	x2, [ap]
+L(1):
+	ldr	x2, [ap]
 	and	x0, x2, #0xffffffffffff
 	add	x0, x0, x2, lsr #48
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/mul_1.asm
+++ b/mpn/arm64/mul_1.asm
@@ -51,19 +51,24 @@ define(`v0', `x3')
 
 
 PROLOGUE(mpn_mul_1c)
+	BTI_C
 	adds	xzr, xzr, xzr		C clear cy flag
 	b	L(com)
 EPILOGUE()
 
 PROLOGUE(mpn_mul_1)
+	BTI_C
 	adds	x4, xzr, xzr		C clear register and cy flag
-L(com):	lsr	x17, n, #2
+L(com):
+	lsr	x17, n, #2
 	tbnz	n, #0, L(bx1)
 
-L(bx0):	mov	x11, x4
+L(bx0):
+	mov	x11, x4
 	tbz	n, #1, L(b00)
 
-L(b10):	ldp	x4, x5, [up]
+L(b10):
+	ldp	x4, x5, [up]
 	mul	x8, x4, v0
 	umulh	x10, x4, v0
 	cbz	x17, L(2)
@@ -71,19 +76,23 @@ L(b10):	ldp	x4, x5, [up]
 	mul	x9, x5, v0
 	b	L(mid)-8
 
-L(2):	mul	x9, x5, v0
+L(2):
+	mul	x9, x5, v0
 	b	L(2e)
 
-L(bx1):	ldr	x7, [up],#8
+L(bx1):
+	ldr	x7, [up],#8
 	mul	x9, x7, v0
 	umulh	x11, x7, v0
 	adds	x9, x9, x4
 	str	x9, [rp],#8
 	tbnz	n, #1, L(b10)
 
-L(b01):	cbz	x17, L(1)
+L(b01):
+	cbz	x17, L(1)
 
-L(b00):	ldp	x6, x7, [up]
+L(b00):
+	ldp	x6, x7, [up]
 	mul	x8, x6, v0
 	umulh	x10, x6, v0
 	ldp	x4, x5, [up,#16]
@@ -95,7 +104,8 @@ L(b00):	ldp	x6, x7, [up]
 	cbz	x17, L(end)
 
 	ALIGN(16)
-L(top):	mul	x8, x4, v0
+L(top):
+	mul	x8, x4, v0
 	ldp	x6, x7, [up,#32]!
 	adcs	x13, x9, x10
 	umulh	x10, x4, v0
@@ -103,7 +113,8 @@ L(top):	mul	x8, x4, v0
 	stp	x12, x13, [rp,#-16]
 	adcs	x12, x8, x11
 	umulh	x11, x5, v0
-L(mid):	mul	x8, x6, v0
+L(mid):
+	mul	x8, x6, v0
 	ldp	x4, x5, [up,#16]
 	adcs	x13, x9, x10
 	umulh	x10, x6, v0
@@ -114,15 +125,19 @@ L(mid):	mul	x8, x6, v0
 	sub	x17, x17, #1
 	cbnz	x17, L(top)
 
-L(end):	mul	x8, x4, v0
+L(end):
+	mul	x8, x4, v0
 	adcs	x13, x9, x10
 	umulh	x10, x4, v0
 	mul	x9, x5, v0
 	stp	x12, x13, [rp,#-16]
-L(2e):	adcs	x12, x8, x11
+L(2e):
+	adcs	x12, x8, x11
 	umulh	x11, x5, v0
 	adcs	x13, x9, x10
 	stp	x12, x13, [rp]
-L(1):	adc	x0, x11, xzr
+L(1):
+	adc	x0, x11, xzr
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/rsh1aors_n.asm
+++ b/mpn/arm64/rsh1aors_n.asm
@@ -56,18 +56,22 @@ ifdef(`OPERATION_rsh1sub_n', `
   define(`func_n',	mpn_rsh1sub_n)')
 
 MULFUNC_PROLOGUE(mpn_rsh1add_n mpn_rsh1sub_n)
+	BTI_C
 
 ASM_START()
 PROLOGUE(func_n)
+	BTI_C
 	lsr	x6, n, #2
 
 	tbz	n, #0, L(bx0)
 
-L(bx1):	ldr	x5, [up],#8
+L(bx1):
+	ldr	x5, [up],#8
 	ldr	x9, [vp],#8
 	tbnz	n, #1, L(b11)
 
-L(b01):	ADDSUB	x13, x5, x9
+L(b01):
+	ADDSUB	x13, x5, x9
 	and	x10, x13, #1
 	cbz	x6, L(1)
 	ldp	x4, x5, [up],#48
@@ -84,13 +88,15 @@ L(b01):	ADDSUB	x13, x5, x9
 	cbz	x6, L(end)
 	b	L(top)
 
-L(1):	cset	x14, COND
+L(1):
+	cset	x14, COND
 	extr	x17, x14, x13, #1
 	str	x17, [rp]
 	mov	x0, x10
 	ret
 
-L(b11):	ADDSUB	x15, x5, x9
+L(b11):
+	ADDSUB	x15, x5, x9
 	and	x10, x15, #1
 
 	ldp	x4, x5, [up],#32
@@ -106,13 +112,16 @@ L(b11):	ADDSUB	x15, x5, x9
 	str	x17, [rp], #8
 	b	L(mid)
 
-L(3):	extr	x17, x12, x15, #1
+L(3):
+	extr	x17, x12, x15, #1
 	str	x17, [rp], #8
 	b	L(2)
 
-L(bx0):	tbz	n, #1, L(b00)
+L(bx0):
+	tbz	n, #1, L(b00)
 
-L(b10):	ldp	x4, x5, [up],#32
+L(b10):
+	ldp	x4, x5, [up],#32
 	ldp	x8, x9, [vp],#32
 	ADDSUB	x12, x4, x8
 	ADDSUBC	x13, x5, x9
@@ -124,7 +133,8 @@ L(b10):	ldp	x4, x5, [up],#32
 	ADDSUBC	x15, x5, x9
 	b	L(mid)
 
-L(b00):	ldp	x4, x5, [up],#48
+L(b00):
+	ldp	x4, x5, [up],#48
 	ldp	x8, x9, [vp],#48
 	ADDSUB	x14, x4, x8
 	ADDSUBC	x15, x5, x9
@@ -138,14 +148,16 @@ L(b00):	ldp	x4, x5, [up],#48
 	cbz	x6, L(end)
 
 	ALIGN(16)
-L(top):	ldp	x4, x5, [up,#-16]
+L(top):
+	ldp	x4, x5, [up,#-16]
 	ldp	x8, x9, [vp,#-16]
 	extr	x16, x15, x14, #1
 	extr	x17, x12, x15, #1
 	ADDSUBC	x14, x4, x8
 	ADDSUBC	x15, x5, x9
 	stp	x16, x17, [rp,#-16]
-L(mid):	ldp	x4, x5, [up],#32
+L(mid):
+	ldp	x4, x5, [up],#32
 	ldp	x8, x9, [vp],#32
 	extr	x16, x13, x12, #1
 	extr	x17, x14, x13, #1
@@ -155,14 +167,18 @@ L(mid):	ldp	x4, x5, [up],#32
 	sub	x6, x6, #1
 	cbnz	x6, L(top)
 
-L(end):	extr	x16, x15, x14, #1
+L(end):
+	extr	x16, x15, x14, #1
 	extr	x17, x12, x15, #1
 	stp	x16, x17, [rp,#-16]
-L(2):	cset	x14, COND
+L(2):
+	cset	x14, COND
 	extr	x16, x13, x12, #1
 	extr	x17, x14, x13, #1
 	stp	x16, x17, [rp]
 
-L(ret):	mov	x0, x10
+L(ret):
+	mov	x0, x10
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/rshift.asm
+++ b/mpn/arm64/rshift.asm
@@ -58,34 +58,41 @@ define(`NSHIFT', lsl)
 
 ASM_START()
 PROLOGUE(mpn_rshift)
+	BTI_C
 	mov	rp, rp_arg
 	sub	tnc, xzr, cnt
 	lsr	x17, n, #2
 	tbz	n, #0, L(bx0)
 
-L(bx1):	ldr	x5, [up]
+L(bx1):
+	ldr	x5, [up]
 	tbnz	n, #1, L(b11)
 
-L(b01):	NSHIFT	x0, x5, tnc
+L(b01):
+	NSHIFT	x0, x5, tnc
 	PSHIFT	x2, x5, cnt
 	cbnz	x17, L(gt1)
 	str	x2, [rp]
 	ret
-L(gt1):	ldp	x4, x5, [up,#8]
+L(gt1):
+	ldp	x4, x5, [up,#8]
 	sub	up, up, #8
 	sub	rp, rp, #32
 	b	L(lo2)
 
-L(b11):	NSHIFT	x0, x5, tnc
+L(b11):
+	NSHIFT	x0, x5, tnc
 	PSHIFT	x2, x5, cnt
 	ldp	x6, x7, [up,#8]!
 	sub	rp, rp, #16
 	b	L(lo3)
 
-L(bx0):	ldp	x4, x5, [up]
+L(bx0):
+	ldp	x4, x5, [up]
 	tbz	n, #1, L(b00)
 
-L(b10):	NSHIFT	x0, x4, tnc
+L(b10):
+	NSHIFT	x0, x4, tnc
 	PSHIFT	x13, x4, cnt
 	NSHIFT	x10, x5, tnc
 	PSHIFT	x2, x5, cnt
@@ -93,12 +100,14 @@ L(b10):	NSHIFT	x0, x4, tnc
 	orr	x10, x10, x13
 	stp	x10, x2, [rp]
 	ret
-L(gt2):	ldp	x4, x5, [up,#16]
+L(gt2):
+	ldp	x4, x5, [up,#16]
 	orr	x10, x10, x13
 	str	x10, [rp],#-24
 	b	L(lo2)
 
-L(b00):	NSHIFT	x0, x4, tnc
+L(b00):
+	NSHIFT	x0, x4, tnc
 	PSHIFT	x13, x4, cnt
 	NSHIFT	x10, x5, tnc
 	PSHIFT	x2, x5, cnt
@@ -108,12 +117,14 @@ L(b00):	NSHIFT	x0, x4, tnc
 	b	L(lo0)
 
 	ALIGN(16)
-L(top):	ldp	x4, x5, [up,#16]
+L(top):
+	ldp	x4, x5, [up,#16]
 	orr	x10, x10, x13
 	orr	x11, x12, x2
 	stp	x11, x10, [rp,#16]
 	PSHIFT	x2, x7, cnt
-L(lo2):	NSHIFT	x10, x5, tnc
+L(lo2):
+	NSHIFT	x10, x5, tnc
 	NSHIFT	x12, x4, tnc
 	PSHIFT	x13, x4, cnt
 	ldp	x6, x7, [up,#32]!
@@ -121,16 +132,20 @@ L(lo2):	NSHIFT	x10, x5, tnc
 	orr	x11, x12, x2
 	stp	x11, x10, [rp,#32]!
 	PSHIFT	x2, x5, cnt
-L(lo0):	sub	x17, x17, #1
-L(lo3):	NSHIFT	x10, x7, tnc
+L(lo0):
+	sub	x17, x17, #1
+L(lo3):
+	NSHIFT	x10, x7, tnc
 	NSHIFT	x12, x6, tnc
 	PSHIFT	x13, x6, cnt
 	cbnz	x17, L(top)
 
-L(end):	orr	x10, x10, x13
+L(end):
+	orr	x10, x10, x13
 	orr	x11, x12, x2
 	PSHIFT	x2, x7, cnt
 	stp	x11, x10, [rp,#16]
 	str	x2, [rp,#32]
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/sec_tabselect.asm
+++ b/mpn/arm64/sec_tabselect.asm
@@ -57,6 +57,7 @@ define(`maskq',  `v4')
 
 ASM_START()
 PROLOGUE(mpn_sec_tabselect)
+	BTI_C
 	dup	v7.2d, x4			C 2 `which' copies
 
 	mov	x10, #1
@@ -66,13 +67,15 @@ PROLOGUE(mpn_sec_tabselect)
 	b.mi	L(outer_end)
 
 L(outer_top):
+
 	mov	i, nents
 	mov	x12, tp				C preserve tp
 	movi	v5.16b, #0			C zero 2 counter copies
 	movi	v2.16b, #0
 	movi	v3.16b, #0
 	ALIGN(16)
-L(tp4):	cmeq	maskq.2d, v5.2d, v7.2d		C compare idx copies to `which' copies
+L(tp4):
+	cmeq	maskq.2d, v5.2d, v7.2d		C compare idx copies to `which' copies
 	ld1	{v0.2d,v1.2d}, [tp]
 	add	v5.2d, v5.2d, v6.2d
 	bit	v2.16b, v0.16b, maskq.16b
@@ -86,13 +89,15 @@ L(tp4):	cmeq	maskq.2d, v5.2d, v7.2d		C compare idx copies to `which' copies
 	b.pl	L(outer_top)
 L(outer_end):
 
+
 	tbz	n, #1, L(b0x)
 	mov	i, nents
 	mov	x12, tp
 	movi	v5.16b, #0			C zero 2 counter copies
 	movi	v2.16b, #0
 	ALIGN(16)
-L(tp2):	cmeq	maskq.2d, v5.2d, v7.2d
+L(tp2):
+	cmeq	maskq.2d, v5.2d, v7.2d
 	ld1	{v0.2d}, [tp]
 	add	v5.2d, v5.2d, v6.2d
 	bit	v2.16b, v0.16b, maskq.16b
@@ -102,13 +107,15 @@ L(tp2):	cmeq	maskq.2d, v5.2d, v7.2d
 	st1	{v2.2d}, [rp], #16
 	add	tp, x12, #16
 
-L(b0x):	tbz	n, #0, L(b00)
+L(b0x):
+	tbz	n, #0, L(b00)
 	mov	i, nents
 	mov	x12, tp
 	movi	v5.16b, #0			C zero 2 counter copies
 	movi	v2.16b, #0
 	ALIGN(16)
-L(tp1):	cmeq	maskq.2d, v5.2d, v7.2d
+L(tp1):
+	cmeq	maskq.2d, v5.2d, v7.2d
 	ld1	{v0.1d}, [tp]
 	add	v5.2d, v5.2d, v6.2d		C FIXME size should be `1d'
 	bit	v2.8b, v0.8b, maskq.8b
@@ -118,5 +125,7 @@ L(tp1):	cmeq	maskq.2d, v5.2d, v7.2d
 	st1	{v2.1d}, [rp], #8
 	add	tp, x12, #8
 
-L(b00):	ret
+L(b00):
+	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/arm64/sqr_diag_addlsh1.asm
+++ b/mpn/arm64/sqr_diag_addlsh1.asm
@@ -46,18 +46,21 @@ define(`n',  `x3')
 
 ASM_START()
 PROLOGUE(mpn_sqr_diag_addlsh1)
+	BTI_C
 	ldr	x15, [up],#8
 	lsr	x14, n, #1
 	tbz	n, #0, L(bx0)
 
-L(bx1):	adds	x7, xzr, xzr
+L(bx1):
+	adds	x7, xzr, xzr
 	mul	x12, x15, x15
 	ldr	x16, [up],#8
 	ldp	x4, x5, [tp],#16
 	umulh	x11, x15, x15
 	b	L(mid)
 
-L(bx0):	adds	x5, xzr, xzr
+L(bx0):
+	adds	x5, xzr, xzr
 	mul	x12, x15, x15
 	ldr	x17, [up],#16
 	ldp	x6, x7, [tp],#32
@@ -66,7 +69,8 @@ L(bx0):	adds	x5, xzr, xzr
 	cbz	x14, L(end)
 
 	ALIGN(16)
-L(top):	extr	x9, x6, x5, #63
+L(top):
+	extr	x9, x6, x5, #63
 	mul	x10, x17, x17
 	ldr	x16, [up,#-8]
 	adcs	x13, x9, x11
@@ -75,7 +79,8 @@ L(top):	extr	x9, x6, x5, #63
 	extr	x8, x7, x6, #63
 	stp	x12, x13, [rp],#16
 	adcs	x12, x8, x10
-L(mid):	extr	x9, x4, x7, #63
+L(mid):
+	extr	x9, x4, x7, #63
 	mul	x10, x16, x16
 	ldr	x17, [up],#16
 	adcs	x13, x9, x11
@@ -87,7 +92,8 @@ L(mid):	extr	x9, x4, x7, #63
 	sub	x14, x14, #1
 	cbnz	x14, L(top)
 
-L(end):	extr	x9, x6, x5, #63
+L(end):
+	extr	x9, x6, x5, #63
 	mul	x10, x17, x17
 	adcs	x13, x9, x11
 	umulh	x11, x17, x17
@@ -100,3 +106,4 @@ L(end):	extr	x9, x6, x5, #63
 
 	ret
 EPILOGUE()
+ADD_GNU_NOTES_IF_NEEDED

--- a/mpn/m4-ccas
+++ b/mpn/m4-ccas
@@ -49,6 +49,8 @@ CC=
 DEFS=
 ASM=
 SEEN_O=no
+M4_GENPATH=
+M4_GENERATED=
 
 for i in "$@"; do
   case $i in
@@ -72,6 +74,9 @@ for i in "$@"; do
     -o)
       SEEN_O=yes
       CC="$CC $i"
+      ;;
+    --m4-gen-path=*)
+      M4_GENPATH=`echo "$i" | sed 's/^--m4-gen-path=//'`
       ;;
     *)
       CC="$CC $i"
@@ -97,11 +102,23 @@ if test $SEEN_O = no; then
   CC="$CC -o $BASENAME.o"
 fi
 
-echo "$M4 $DEFS $ASM >$TMP"
-$M4 $DEFS $ASM >$TMP || exit
+# Does the architecture have any dynamically generated m4?
+# if so execute the generation script
+if test -n "$M4_GENPATH"; then
+  if ! test -f "$M4_GENPATH"; then
+    echo "$M4_GENPATH not found."
+    exit 1
+  fi
+  echo "$M4_GENPATH \"$CC\""
+  M4_GENERATED="${TMP%.*}.m4"
+  "$M4_GENPATH" "$CC" > "$M4_GENERATED" || exit
+fi
+
+echo "$M4 $DEFS $M4_GENERATED $ASM >$TMP"
+$M4 $DEFS "$M4_GENERATED" $ASM >$TMP || exit
 
 echo "$CC"
 $CC || exit
 
 # Comment this out to preserve .s intermediates
-rm -f $TMP
+#rm -f $TMP "$M4_GENERATED"


### PR DESCRIPTION
Enable Pointer Authentication Codes (PAC) and Branch Target Identification (BTI) support for ARM 64 targets.

PAC works by signing the LR with either an A key or B key and verifying the return address. There are quite a few instructions capable of doing this, however, the Linux ARM ABI is to use hint compatible instructions that can be safely NOP'd on older hardware and can be assembled and linked with older binutils. This limits the instruction set to paciasp, pacibsp, autiasp and autibsp. Instructions prefixed with pac are for signing and instructions prefixed with aut are for signing. Both instructions are then followed with an a or b to indicate which signing key they are using. The keys can be controlled using -mbranch-protection=pac-ret for the A key and
-mbranch-protection=pac-ret+b-key for the B key.

BTI works by marking all call and jump positions with bti c and bti j instructions. If execution control transfers to an instruction other than a BTI instruction, the execution is killed via SIGILL. Note that to remove one instruction, the aforementioned pac instructions will also work as a BTI landing pad for bti c usages.

For BTI to work, all object files linked for a unit of execution, whether an executable or a library must have the GNU Notes section of the ELF file marked to indicate BTI support. This is so loader/linkers can apply the proper permission bits (PROT_BRI) on the memory region.

PAC can also be annotated in the GNU ELF notes section, but it's not required for enablement, as interleaved PAC and non-pac code works as expected since it's the callee that performs all the checking. The linker follows the same rules as BTI for discarding the PAC flag from the GNU Notes section.

Testing was done under the following CFLAGS and CXXFLAGS for all combinations:
1. -mbranch-protection=none
2. -mbranch-protection=standard
3. -mbranch-protection=pac-ret
4. -mbranch-protection=pac-ret+b-key
5. -mbranch-protection=bti

Additional Notes:
MPN was handled differently then the standard approach of all PROLOGUES getting a SIGN_LR macro. This is becuase MPN does not make use of saving the x30, aka the link regeister (LR), to the stack in almost all instances. However, some functions do, and they were explicitly handled. This not only avoids the cost of the operations to sign and verify the LR but also handles instances where branches are taken to labels where indirect branches are used over branch and link to optimize the assembly.

Also, within the configure.ac are a myriad of options for different architectures, chipsets, ABIs, etc. To compound that, additional architecture specifiec features could be enabled with in CFLAGS that needs to be respected in-order to get a correct output. For instance in aarch64, the PAC and BTI instructions need to be output in the generated assembly as well as the GNU notes section added to the ELF output to get those security features. Hacking it into the configure options seems baroque, especially considering that distro packaging will often just set a set of CFLAGS to be respected and move on and that's most users would expect. Taking this all into consideration, allowing for a per architecture script that can be executed to generate additional m4 allows for internal definitions, like in the PAC case, to be exposed, or any multitude of options if other archs need somethng like this. This introduces the variable gen_path_m4 that arch's can set to the script of their choosing to generate whatever m4 they need that is prepended to the m4 generation command after the defines.